### PR TITLE
add a description line 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ Please install Sublime [Package Control](https://sublime.wbond.net/installation)
 
 
 ###Settings
-#### The default key binding for Mac is
+#### The default key binding for Mac is 
 
 ```
 { "keys": ["super+k", "super+f"], "command": "sql_beautifier" }
 ```
+
+* Kindly note that the ` super ` key here is generally replaced by ` Command (⌘)` key
 
 #### The default key binding for Windows / Linux is
 


### PR DESCRIPTION
I was actually little bit confused about the description of the README. 
I think the term ` super key ` seldom uses so I would recommend to use ` command key (⌘) ` instead so that the readers easily introduce the extension features when they use it. 